### PR TITLE
Remove stale server PID file on build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ db/footprints_test.db
 sinatra/
 .rspec-local
 db/*.sqlite3
+db/*.db3

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -263,6 +263,3 @@ DEPENDENCIES
   uglifier (>= 1.3.0)
   unicorn (~> 4.8.2)
   will_paginate (~> 3.0.5)
-
-BUNDLED WITH
-   1.16.3

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ cd /path/to/footprints-public
 docker-compose up
 ``` 
 
-This step should bring up the Rails application. Browse to [http://localhost:3000](http://localhost:3000) and you should see a web application running.
+This step should run the Rails application, **which may fail if you have not run the migrations yet**. Browse to [http://localhost:3000](http://localhost:3000) and you should see a web application running.
 
 3. To manage gems, or run Rails, Bundler, or Rake commands, you will want to do that from inside of the running Ruby container:
 
@@ -53,7 +53,9 @@ cd /path/to/footprints-public
 docker-compose exec ruby bash
 ```
 
-4. To bring the application back down, run `docker-compose down`
+4. To run the migrations, use the instructions from the previous step to open a bash session inside of the running `ruby` container, and then execute the command `bin/rake db:migrate` to run all of the migrations.
+
+5. To bring the application back down, run `docker-compose down`
 
 #### Note
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,6 @@ services:
     build:
       context: .
       dockerfile: ./docker/ruby/Dockerfile
-    command: bin/rails s -p 3000 -b '0.0.0.0'
     environment:
       RAILS_ENV: development
     volumes:

--- a/docker-entry.sh
+++ b/docker-entry.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+set -e
+
+if [ -f tmp/pids/server.pid ]; then
+  rm tmp/pids/server.pid
+fi
+
+exec bundle exec "$@"

--- a/docker/ruby/Dockerfile
+++ b/docker/ruby/Dockerfile
@@ -14,9 +14,6 @@ RUN bundle install
 # Copy in application's source
 COPY . /app
 
-# Apply migrations
-RUN bin/rake db:migrate
-
 ENTRYPOINT ["/app/docker-entry.sh"]
 
 CMD ["bin/rails", "s", "-p", "3000", "-b", "0.0.0.0"]

--- a/docker/ruby/Dockerfile
+++ b/docker/ruby/Dockerfile
@@ -14,8 +14,9 @@ RUN bundle install
 # Copy in application's source
 COPY . /app
 
-# Remove any stale PID tmp files on build
-RUN rm /app/tmp/pids/server.pid
-
 # Apply migrations
 RUN bin/rake db:migrate
+
+ENTRYPOINT ["/app/docker-entry.sh"]
+
+CMD ["bin/rails", "s", "-p", "3000", "-b", "0.0.0.0"]

--- a/docker/ruby/Dockerfile
+++ b/docker/ruby/Dockerfile
@@ -14,5 +14,8 @@ RUN bundle install
 # Copy in application's source
 COPY . /app
 
+# Remove any stale PID tmp files on build
+RUN rm /app/tmp/pids/server.pid
+
 # Apply migrations
 RUN bin/rake db:migrate


### PR DESCRIPTION
This PR ensures that a `docker-compose up --build` doesn't fail if a prior instance of the app created a temporary PID file and left it behind. Specifically avoids this error:

```
ruby_1  | => Booting WEBrick
ruby_1  | => Rails 4.0.2 application starting in development on http://0.0.0.0:3000
ruby_1  | => Run `rails server -h` for more startup options
ruby_1  | => Ctrl-C to shutdown server
ruby_1  | WARNING: Deprecated - suite.no_coverage has been removed in Teaspoon 1.0. Please use coverage.ignore instead. https://github.com/modeset/teaspoon/blob/master/CHANGELOG.md
ruby_1  | A server is already running. Check /app/tmp/pids/server.pid.
ruby_1  | Exiting
```