### PR TITLE
Fix require paths

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -19,6 +19,7 @@ gem "edn", '~> 1.0.2'
 gem "httparty", '~> 0.13.0'
 gem "american_date"
 gem 'mysql2', '~> 0.3.18'
+gem 'activerecord-native_db_types_override'
 
 gem 'stockroom', git: 'https://github.com/ryanzverner/stockroom-ruby-client.git'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -28,6 +28,7 @@ GEM
       activesupport (= 4.0.2)
       arel (~> 4.0.0)
     activerecord-deprecated_finders (1.0.4)
+    activerecord-native_db_types_override (0.3.0)
     activeresource (4.1.0)
       activemodel (~> 4.0)
       activesupport (~> 4.0)
@@ -232,6 +233,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  activerecord-native_db_types_override
   american_date
   awesome_print
   better_errors (= 1.1.0)

--- a/app/controllers/craftsmen_controller.rb
+++ b/app/controllers/craftsmen_controller.rb
@@ -1,7 +1,7 @@
-require './lib/repository'
-require './lib/craftsmen/craftsmen_interactor'
-require './lib/craftsmen/craftsmen_presenter'
-require './lib/craftsmen/skills'
+require 'repository'
+require 'craftsmen/craftsmen_interactor'
+require 'craftsmen/craftsmen_presenter'
+require 'craftsmen/skills'
 
 class CraftsmenController < ApplicationController
   before_filter :authenticate, :employee?

--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -1,5 +1,5 @@
-require './lib/applicants/applicant_index_presenter'
-require './lib/dashboard/dashboard_interactor'
+require 'applicants/applicant_index_presenter'
+require 'dashboard/dashboard_interactor'
 
 class DashboardController < ApplicationController
   before_filter :authenticate, :employee?

--- a/app/controllers/salaries_controller.rb
+++ b/app/controllers/salaries_controller.rb
@@ -1,6 +1,6 @@
-require './lib/salaries/salary_presenter'
-require './lib/salaries/salary_updater'
-require './lib/repository'
+require 'salaries/salary_presenter'
+require 'salaries/salary_updater'
+require 'repository'
 
 class SalariesController < ApplicationController
   before_filter :authenticate, :employee?

--- a/app/mailers/notification_mailer.rb
+++ b/app/mailers/notification_mailer.rb
@@ -1,4 +1,4 @@
-require './lib/applicants/applicant_presenter'
+require 'applicants/applicant_presenter'
 
 class NotificationMailer < ActionMailer::Base
   default :from => "noreply@abcinc.com"

--- a/config/initializers/repository.rb
+++ b/config/initializers/repository.rb
@@ -1,4 +1,4 @@
-require './lib/repository'
+require 'repository'
 require 'memory_repository/memory_repository'
 require 'ar_repository/ar_repository'
 

--- a/config/initializers/warehouse.rb
+++ b/config/initializers/warehouse.rb
@@ -1,5 +1,5 @@
-require './lib/warehouse/api_factory'
-require './lib/warehouse/fake_api'
+require 'warehouse/api_factory'
+require 'warehouse/fake_api'
 require 'warehouse/json_api'
 
 if Rails.env.local?

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,4 @@
-require './lib/ar_repository/models/user'
+require 'ar_repository/models/user'
 
 Footprints::Application.routes.draw do
 

--- a/lib/applicants/applicant_finder.rb
+++ b/lib/applicants/applicant_finder.rb
@@ -1,4 +1,4 @@
-require './lib/repository'
+require 'repository'
 
 module Footprints
   class ApplicantFinder

--- a/lib/applicants/applicant_profile_presenter.rb
+++ b/lib/applicants/applicant_profile_presenter.rb
@@ -1,5 +1,5 @@
 require "./app/validators/url_validator"
-require "./lib/argon/applicant_offer_letter_generator"
+require "argon/applicant_offer_letter_generator"
 
 class ApplicantProfilePresenter
   include ApplicantsHelper

--- a/lib/ar_repository/ar_repository.rb
+++ b/lib/ar_repository/ar_repository.rb
@@ -6,7 +6,7 @@ dbconfig = YAML.safe_load(File.open(db_yaml))
 
 ActiveRecord::Base.establish_connection(dbconfig[Rails.env])
 
-require './lib/repository'
+require 'repository'
 require 'ar_repository/applicant_repository'
 require 'ar_repository/craftsman_repository'
 require 'ar_repository/apprentice_repository'

--- a/lib/ar_repository/models/annual_starting_craftsman_salary.rb
+++ b/lib/ar_repository/models/annual_starting_craftsman_salary.rb
@@ -1,4 +1,4 @@
-require './lib/repository'
+require 'repository'
 
 class AnnualStartingCraftsmanSalary < ActiveRecord::Base
 

--- a/lib/ar_repository/models/applicant.rb
+++ b/lib/ar_repository/models/applicant.rb
@@ -1,4 +1,4 @@
-require './lib/repository'
+require 'repository'
 require './app/helpers/applicants_helper'
 require './app/validators/date_validator'
 require './app/validators/url_validator'

--- a/lib/ar_repository/models/assigned_craftsman_record.rb
+++ b/lib/ar_repository/models/assigned_craftsman_record.rb
@@ -1,4 +1,4 @@
-require './lib/repository'
+require 'repository'
 class AssignedCraftsmanRecord < ActiveRecord::Base
   belongs_to :craftsman
   belongs_to :applicant

--- a/lib/ar_repository/models/craftsman.rb
+++ b/lib/ar_repository/models/craftsman.rb
@@ -1,5 +1,5 @@
-require './lib/repository'
-require './lib/craftsmen/skills'
+require 'repository'
+require 'craftsmen/skills'
 
 class Craftsman < ActiveRecord::Base
   include ActiveModel::Validations

--- a/lib/ar_repository/models/message.rb
+++ b/lib/ar_repository/models/message.rb
@@ -1,4 +1,4 @@
-require './lib/repository'
+require 'repository'
 class Message < ActiveRecord::Base
   belongs_to :applicant 
 end

--- a/lib/ar_repository/models/monthly_apprentice_salary.rb
+++ b/lib/ar_repository/models/monthly_apprentice_salary.rb
@@ -1,4 +1,4 @@
-require './lib/repository'
+require 'repository'
 
 class MonthlyApprenticeSalary < ActiveRecord::Base
 

--- a/lib/ar_repository/models/note.rb
+++ b/lib/ar_repository/models/note.rb
@@ -1,4 +1,4 @@
-require './lib/repository'
+require 'repository'
 
 class Note < ActiveRecord::Base
 

--- a/lib/ar_repository/models/user.rb
+++ b/lib/ar_repository/models/user.rb
@@ -1,4 +1,4 @@
-require './lib/repository'
+require 'repository'
 
 class User < ActiveRecord::Base
   include ActiveModel::Validations

--- a/lib/craftsmen/craftsmen_presenter.rb
+++ b/lib/craftsmen/craftsmen_presenter.rb
@@ -1,4 +1,4 @@
-require './lib/craftsmen/skills'
+require 'craftsmen/skills'
 
 class CraftsmenPresenter
   def initialize(craftsmen)

--- a/lib/highrise/highrise_puller_interactor.rb
+++ b/lib/highrise/highrise_puller_interactor.rb
@@ -1,4 +1,4 @@
-require './lib/repository'
+require 'repository'
 require 'highrise'
 module Interactor
   class HighrisePuller

--- a/lib/memory_repository/applicant_repository.rb
+++ b/lib/memory_repository/applicant_repository.rb
@@ -1,6 +1,6 @@
 require 'memory_repository/models/applicant'
 require 'memory_repository/base_repository'
-require './lib/repository'
+require 'repository'
 
 module MemoryRepository
   class ApplicantRepository

--- a/lib/memory_repository/craftsman_repository.rb
+++ b/lib/memory_repository/craftsman_repository.rb
@@ -1,6 +1,6 @@
 require 'memory_repository/models/craftsman'
 require 'memory_repository/base_repository'
-require './lib/repository'
+require 'repository'
 
 module MemoryRepository
   class CraftsmanRepository

--- a/lib/memory_repository/memory_repository.rb
+++ b/lib/memory_repository/memory_repository.rb
@@ -1,8 +1,8 @@
-require './lib/memory_repository/applicant_repository'
-require './lib/memory_repository/craftsman_repository'
-require './lib/memory_repository/user_repository'
-require './lib/memory_repository/assigned_craftsman_record_repository'
-require './lib/memory_repository/message_repository'
+require 'memory_repository/applicant_repository'
+require 'memory_repository/craftsman_repository'
+require 'memory_repository/user_repository'
+require 'memory_repository/assigned_craftsman_record_repository'
+require 'memory_repository/message_repository'
 
 module MemoryRepository
   def self.applicant

--- a/lib/memory_repository/message_repository.rb
+++ b/lib/memory_repository/message_repository.rb
@@ -1,6 +1,6 @@
 require 'memory_repository/models/message'
 require 'memory_repository/base_repository'
-require './lib/repository'
+require 'repository'
 
 module MemoryRepository
   class MessageRepository

--- a/lib/memory_repository/note_repository.rb
+++ b/lib/memory_repository/note_repository.rb
@@ -1,6 +1,6 @@
 require 'memory_repository/models/note'
 require 'memory_repository/base_repository'
-require './lib/repository'
+require 'repository'
 
 module MemoryRepository
   class NoteRepository

--- a/lib/memory_repository/user_repository.rb
+++ b/lib/memory_repository/user_repository.rb
@@ -1,6 +1,6 @@
 require 'memory_repository/models/user'
 require 'memory_repository/base_repository'
-require './lib/repository'
+require 'repository'
 
 module MemoryRepository
   class UserRepository

--- a/lib/notes/notes_presenter.rb
+++ b/lib/notes/notes_presenter.rb
@@ -1,4 +1,4 @@
-require './lib/notes/note_presenter'
+require 'notes/note_presenter'
 
 class NotesPresenter
   def initialize(notes)

--- a/lib/patches/abstract_mysql2_adapter.rb
+++ b/lib/patches/abstract_mysql2_adapter.rb
@@ -1,6 +1,10 @@
 # Ensure the mysql2 gem uses the correct column definition for MySQL 5.7+
 #
 # @see https://stackoverflow.com/questions/21075515/creating-tables-and-problems-with-primary-key-in-rails
-class ActiveRecord::ConnectionAdapters::Mysql2Adapter
-  NATIVE_DATABASE_TYPES[:primary_key] = "int(11) auto_increment PRIMARY KEY"
-end
+# @see https://stackoverflow.com/questions/37315546/uninitialized-constant-activerecordconnectionadaptersmysql2adapternative-d
+require 'active_record/connection_adapters/mysql2_adapter'
+NativeDbTypesOverride.configure({
+  ActiveRecord::ConnectionAdapters::Mysql2Adapter => {
+    primary_key: "int(11) auto_increment PRIMARY KEY"
+  }
+})

--- a/lib/reporting/reporting_interactor.rb
+++ b/lib/reporting/reporting_interactor.rb
@@ -1,10 +1,10 @@
 require 'warehouse/json_api'
 require 'warehouse/token_http_client'
-require './lib/reporting/data_parser'
-require './lib/reporting/real_data_parser'
-require './lib/reporting/real_employment_data_generator'
-require './lib/warehouse/api_factory'
-require './lib/warehouse/fake_api'
+require 'reporting/data_parser'
+require 'reporting/real_data_parser'
+require 'reporting/real_employment_data_generator'
+require 'warehouse/api_factory'
+require 'warehouse/fake_api'
 require 'repository'
 
 class ReportingInteractor

--- a/lib/tasks/applicants.rake
+++ b/lib/tasks/applicants.rake
@@ -1,6 +1,6 @@
-require './lib/highrise/highrise_puller_interactor'
-require './lib/repository'
-require './lib/reminder/reminder'
+require 'highrise/highrise_puller_interactor'
+require 'repository'
+require 'reminder/reminder'
 
 namespace :db do
   desc "Destroys all Applicant Records for Staging"

--- a/lib/tasks/craftsman.rake
+++ b/lib/tasks/craftsman.rake
@@ -1,4 +1,4 @@
-require './lib/repository'
+require 'repository'
 
 namespace :db do
   desc "Destroys all Craftsmen Records for Staging"

--- a/lib/tasks/db.rake
+++ b/lib/tasks/db.rake
@@ -1,5 +1,5 @@
-require './lib/repository'
-require './lib/applicants/applicant_archiver'
+require 'repository'
+require 'applicants/applicant_archiver'
 
 namespace :db do
   desc "Destroys Everything from Databases"

--- a/lib/tasks/messages.rake
+++ b/lib/tasks/messages.rake
@@ -1,5 +1,5 @@
-require './lib/highrise/highrise_puller_interactor'
-require './lib/repository'
+require 'highrise/highrise_puller_interactor'
+require 'repository'
 
 namespace :db do
   desc "Destroys all messages"

--- a/lib/warehouse/api_factory.rb
+++ b/lib/warehouse/api_factory.rb
@@ -1,4 +1,4 @@
-require './lib/warehouse/fake_api'
+require 'warehouse/fake_api'
 require 'warehouse/json_api'
 
 module Warehouse

--- a/spec/argon/applicant_offer_letter_generator_spec.rb
+++ b/spec/argon/applicant_offer_letter_generator_spec.rb
@@ -1,6 +1,6 @@
 # encoding: utf-8
 require 'spec_helper'
-require './lib/argon/applicant_offer_letter_generator.rb'
+require 'argon/applicant_offer_letter_generator.rb'
 
 describe ApplicantOfferLetterGenerator do
   let!(:craftsman) { Footprints::Repository.craftsman.create(:name => "A Craftsman", :employment_id => "007") }

--- a/spec/argon/offer_letter_post_spec.rb
+++ b/spec/argon/offer_letter_post_spec.rb
@@ -1,5 +1,5 @@
 require "spec_helper"
-require './lib/argon/offer_letter_post.rb'
+require 'argon/offer_letter_post.rb'
 
 describe OfferLetterPost do
   it "gets a PDF from Argon" do

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -1,5 +1,5 @@
 require 'spec_helper'
-require './lib/memory_repository/models/user'
+require 'memory_repository/models/user'
 
 describe UsersController do
   before(:each) do

--- a/spec/craftsmen/craftsmen_interactor_spec.rb
+++ b/spec/craftsmen/craftsmen_interactor_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helpers/craftsman_factory'
 
-require './lib/craftsmen/craftsmen_interactor'
+require 'craftsmen/craftsmen_interactor'
 
 describe CraftsmenInteractor do
   let(:craftsman) { SpecHelpers::CraftsmanFactory.new.create }

--- a/spec/craftsmen/skills_spec.rb
+++ b/spec/craftsmen/skills_spec.rb
@@ -1,4 +1,4 @@
-require './lib/craftsmen/skills'
+require 'craftsmen/skills'
 
 describe Skills do
   it 'converts list of given skills into single key' do

--- a/spec/footprints-ar-repository/annual_starting_craftsman_salary_repository_spec.rb
+++ b/spec/footprints-ar-repository/annual_starting_craftsman_salary_repository_spec.rb
@@ -1,5 +1,5 @@
 require 'spec_helper'
-require './lib/ar_repository/annual_starting_craftsman_salary_repository'
+require 'ar_repository/annual_starting_craftsman_salary_repository'
 require './spec/footprints/shared_examples/annual_starting_craftsman_salary_examples'
 
 describe ArRepository::AnnualStartingCraftsmanSalaryRepository do

--- a/spec/footprints-ar-repository/applicant_repository_spec.rb
+++ b/spec/footprints-ar-repository/applicant_repository_spec.rb
@@ -1,5 +1,5 @@
 require 'spec_helper'
-require './lib/ar_repository/applicant_repository'
+require 'ar_repository/applicant_repository'
 require './spec/footprints/shared_examples/applicant_examples'
 
 describe ArRepository::ApplicantRepository do

--- a/spec/footprints-ar-repository/ar_repository_spec.rb
+++ b/spec/footprints-ar-repository/ar_repository_spec.rb
@@ -1,5 +1,5 @@
 require "spec_helper"
-require "./lib/ar_repository/ar_repository"
+require "ar_repository/ar_repository"
 
 describe ArRepository do
   it "has an applicant repo" do

--- a/spec/footprints-ar-repository/assigned_craftsman_record_repository_spec.rb
+++ b/spec/footprints-ar-repository/assigned_craftsman_record_repository_spec.rb
@@ -1,5 +1,5 @@
 require 'spec_helper'
-require './lib/ar_repository/assigned_craftsman_record_repository'
+require 'ar_repository/assigned_craftsman_record_repository'
 require './spec/footprints/shared_examples/assigned_craftsman_record_examples'
 
 describe ArRepository::AssignedCraftsmanRecordRepository do

--- a/spec/footprints-ar-repository/craftsman_repository_spec.rb
+++ b/spec/footprints-ar-repository/craftsman_repository_spec.rb
@@ -1,5 +1,5 @@
 require 'spec_helper'
-require "./lib/ar_repository/craftsman_repository"
+require "ar_repository/craftsman_repository"
 require "./spec/footprints/shared_examples/craftsman_examples.rb"
 
 describe ArRepository::CraftsmanRepository do

--- a/spec/footprints-ar-repository/message_repository_spec.rb
+++ b/spec/footprints-ar-repository/message_repository_spec.rb
@@ -1,5 +1,5 @@
 require 'spec_helper'
-require './lib/ar_repository/message_repository'
+require 'ar_repository/message_repository'
 require './spec/footprints/shared_examples/message_examples'
 
 describe ArRepository::MessageRepository do

--- a/spec/footprints-ar-repository/monthly_apprentice_salary_repository_spec.rb
+++ b/spec/footprints-ar-repository/monthly_apprentice_salary_repository_spec.rb
@@ -1,5 +1,5 @@
 require 'spec_helper'
-require './lib/ar_repository/monthly_apprentice_salary_repository'
+require 'ar_repository/monthly_apprentice_salary_repository'
 require './spec/footprints/shared_examples/monthly_apprentice_salary_examples'
 
 describe ArRepository::MonthlyApprenticeSalaryRepository do

--- a/spec/footprints-ar-repository/note_repository_spec.rb
+++ b/spec/footprints-ar-repository/note_repository_spec.rb
@@ -1,5 +1,5 @@
 require 'spec_helper'
-require './lib/ar_repository/note_repository'
+require 'ar_repository/note_repository'
 require './spec/footprints/shared_examples/note_examples'
 
 describe ArRepository::NoteRepository do

--- a/spec/footprints-ar-repository/user_repository_spec.rb
+++ b/spec/footprints-ar-repository/user_repository_spec.rb
@@ -1,5 +1,5 @@
 require 'spec_helper'
-require './lib/ar_repository/user_repository'
+require 'ar_repository/user_repository'
 require './spec/footprints/shared_examples/user_examples'
 
 describe ArRepository::UserRepository do

--- a/spec/footprints-memory-repository/applicant_repository_spec.rb
+++ b/spec/footprints-memory-repository/applicant_repository_spec.rb
@@ -1,5 +1,5 @@
 require 'spec_helper'
-require './lib/memory_repository/applicant_repository'
+require 'memory_repository/applicant_repository'
 require './spec/footprints/shared_examples/applicant_examples'
 
 describe MemoryRepository::ApplicantRepository do

--- a/spec/footprints-memory-repository/assigned_craftsman_record_repository_spec.rb
+++ b/spec/footprints-memory-repository/assigned_craftsman_record_repository_spec.rb
@@ -1,5 +1,5 @@
 require 'spec_helper'
-require './lib/memory_repository/assigned_craftsman_record_repository'
+require 'memory_repository/assigned_craftsman_record_repository'
 require './spec/footprints/shared_examples/assigned_craftsman_record_examples'
 
 describe MemoryRepository::AssignedCraftsmanRecordRepository do

--- a/spec/footprints-memory-repository/base_model_spec.rb
+++ b/spec/footprints-memory-repository/base_model_spec.rb
@@ -1,5 +1,5 @@
 require 'spec_helper'
-require './lib/memory_repository/models/base'
+require 'memory_repository/models/base'
 
 class TestBaseModel < MemoryRepository::Base
   data_attributes :name, :hired, :email

--- a/spec/footprints-memory-repository/base_repository_spec.rb
+++ b/spec/footprints-memory-repository/base_repository_spec.rb
@@ -1,5 +1,5 @@
 require 'spec_helper'
-require './lib/memory_repository/base_repository'
+require 'memory_repository/base_repository'
 require 'ostruct'
 
 describe MemoryRepository do

--- a/spec/footprints-memory-repository/craftsman_repository_spec.rb
+++ b/spec/footprints-memory-repository/craftsman_repository_spec.rb
@@ -1,5 +1,5 @@
 require 'spec_helper'
-require './lib/memory_repository/applicant_repository'
+require 'memory_repository/applicant_repository'
 require './spec/footprints/shared_examples/craftsman_examples'
 
 describe MemoryRepository::CraftsmanRepository do

--- a/spec/footprints-memory-repository/memory_repository_spec.rb
+++ b/spec/footprints-memory-repository/memory_repository_spec.rb
@@ -1,8 +1,8 @@
 require 'spec_helper'
-require './lib/memory_repository/applicant_repository'
-require './lib/memory_repository/craftsman_repository'
-require './lib/memory_repository/user_repository'
-require './lib/memory_repository/message_repository'
+require 'memory_repository/applicant_repository'
+require 'memory_repository/craftsman_repository'
+require 'memory_repository/user_repository'
+require 'memory_repository/message_repository'
 
 describe MemoryRepository do
   it "has an applicant repo" do

--- a/spec/footprints-memory-repository/note_repository_spec.rb
+++ b/spec/footprints-memory-repository/note_repository_spec.rb
@@ -1,5 +1,5 @@
 require 'spec_helper'
-require './lib/memory_repository/note_repository'
+require 'memory_repository/note_repository'
 require './spec/footprints/shared_examples/note_examples'
 
 describe MemoryRepository::NoteRepository do

--- a/spec/footprints-memory-repository/user_repository_spec.rb
+++ b/spec/footprints-memory-repository/user_repository_spec.rb
@@ -1,5 +1,5 @@
 require 'spec_helper'
-require './lib/memory_repository/user_repository'
+require 'memory_repository/user_repository'
 require './spec/footprints/shared_examples/user_examples'
 
 describe MemoryRepository::UserRepository do

--- a/spec/footprints/applicants/applicant_archiver_spec.rb
+++ b/spec/footprints/applicants/applicant_archiver_spec.rb
@@ -1,5 +1,5 @@
 require 'spec_helper'
-require './lib/applicants/applicant_archiver'
+require 'applicants/applicant_archiver'
 
 describe Footprints::ApplicantArchiver do
 

--- a/spec/footprints/applicants/applicant_finder_spec.rb
+++ b/spec/footprints/applicants/applicant_finder_spec.rb
@@ -1,5 +1,5 @@
 require 'spec_helper'
-require './lib/applicants/applicant_finder'
+require 'applicants/applicant_finder'
 
 module Footprints
   describe ApplicantFinder do

--- a/spec/footprints/applicants/applicant_index_presenter_spec.rb
+++ b/spec/footprints/applicants/applicant_index_presenter_spec.rb
@@ -1,5 +1,5 @@
 require "spec_helper"
-require "./lib/applicants/applicant_index_presenter"
+require "applicants/applicant_index_presenter"
 
 describe ApplicantIndexPresenter do
 

--- a/spec/footprints/applicants/applicant_interactor_spec.rb
+++ b/spec/footprints/applicants/applicant_interactor_spec.rb
@@ -1,5 +1,5 @@
 require 'spec_helper'
-require './lib/applicants/applicant_interactor.rb'
+require 'applicants/applicant_interactor.rb'
 
 describe ApplicantInteractor do
   let!(:craftsman) { Footprints::Repository.craftsman.create(:name => "A Craftsman", :employment_id => "007", :email => "acraftsman@example.com") }

--- a/spec/footprints/applicants/applicant_presenter_spec.rb
+++ b/spec/footprints/applicants/applicant_presenter_spec.rb
@@ -1,5 +1,5 @@
 require 'spec_helper'
-require "./lib/applicants/applicant_presenter"
+require "applicants/applicant_presenter"
 require 'date'
 
 describe ApplicantPresenter do 

--- a/spec/footprints/applicants/applicant_profile_presenter_spec.rb
+++ b/spec/footprints/applicants/applicant_profile_presenter_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
-require "./lib/applicants/applicant_profile_presenter"
-require "./lib/argon/applicant_offer_letter_generator"
+require "applicants/applicant_profile_presenter"
+require "argon/applicant_offer_letter_generator"
 
 describe ApplicantProfilePresenter do
   let(:applicant) do

--- a/spec/footprints/applicants/eighthlight_interactor_spec.rb
+++ b/spec/footprints/applicants/eighthlight_interactor_spec.rb
@@ -1,5 +1,5 @@
 require 'spec_helper'
-require './lib/applicants/eighthlight_applicants_interactor'
+require 'applicants/eighthlight_applicants_interactor'
 
 describe EighthlightApplicantsInteractor do
   let(:repo)   { Footprints::Repository }

--- a/spec/footprints/craftsmen/craftsmen_presenter_spec.rb
+++ b/spec/footprints/craftsmen/craftsmen_presenter_spec.rb
@@ -1,6 +1,6 @@
 require "spec_helper"
-require "./lib/craftsmen/craftsmen_presenter"
-require './lib/craftsmen/skills'
+require "craftsmen/craftsmen_presenter"
+require 'craftsmen/skills'
 
 describe CraftsmenPresenter do
   before :each do

--- a/spec/footprints/dashboard/dashboard_interactor_spec.rb
+++ b/spec/footprints/dashboard/dashboard_interactor_spec.rb
@@ -1,5 +1,5 @@
 require 'spec_helper'
-require './lib/dashboard/dashboard_interactor'
+require 'dashboard/dashboard_interactor'
 
 describe DashboardInteractor do
   let(:repo) { Footprints::Repository }

--- a/spec/footprints/reminder/reminder_spec.rb
+++ b/spec/footprints/reminder/reminder_spec.rb
@@ -1,4 +1,4 @@
-require './lib/reminder/reminder.rb'
+require 'reminder/reminder.rb'
 require 'spec_helper'
 require 'spec_helpers/applicant_factory'
 require 'spec_helpers/craftsman_factory'

--- a/spec/footprints/reporting/data_parser_spec.rb
+++ b/spec/footprints/reporting/data_parser_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
-require './lib/reporting/data_parser'
-require './lib/warehouse/fake_api'
+require 'reporting/data_parser'
+require 'warehouse/fake_api'
 
 describe DataParser do
   let(:now)              { Time.now.utc }

--- a/spec/footprints/reporting/employment_data_generator_spec.rb
+++ b/spec/footprints/reporting/employment_data_generator_spec.rb
@@ -1,6 +1,6 @@
-require './lib/reporting/employment_data_generator'
-require './lib/reporting/data_parser'
-require './lib/warehouse/fake_api'
+require 'reporting/employment_data_generator'
+require 'reporting/data_parser'
+require 'warehouse/fake_api'
 
 describe EmploymentDataGenerator do
   let(:employment_data)  {

--- a/spec/footprints/reporting/real_data_parser_spec.rb
+++ b/spec/footprints/reporting/real_data_parser_spec.rb
@@ -1,5 +1,5 @@
 require 'spec_helper'
-require './lib/reporting/real_data_parser'
+require 'reporting/real_data_parser'
 
 describe RealDataParser do
   let(:now)              { Time.now.utc }

--- a/spec/footprints/reporting/reporting_interactor_spec.rb
+++ b/spec/footprints/reporting/reporting_interactor_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
-require './lib/warehouse/fake_api'
-require './lib/reporting/reporting_interactor'
+require 'warehouse/fake_api'
+require 'reporting/reporting_interactor'
 require 'warehouse/json_api'
 
 describe ReportingInteractor do

--- a/spec/notes/note_presenter_spec.rb
+++ b/spec/notes/note_presenter_spec.rb
@@ -1,5 +1,5 @@
 require "spec_helper"
-require './lib/notes/note_presenter'
+require 'notes/note_presenter'
 
 describe NotePresenter do
   let(:given_time) { DateTime.parse("01 Jan 2000 12:00:00 -6") }

--- a/spec/salaries/salary_presenter_spec.rb
+++ b/spec/salaries/salary_presenter_spec.rb
@@ -1,6 +1,6 @@
 # encoding: utf-8
 require 'spec_helper'
-require './lib/salaries/salary_presenter'
+require 'salaries/salary_presenter'
 
 describe SalaryPresenter do
   Salary = Struct.new(:id, :duration, :location, :amount)

--- a/spec/salaries/salary_updater_spec.rb
+++ b/spec/salaries/salary_updater_spec.rb
@@ -1,5 +1,5 @@
 require 'spec_helper'
-require './lib/salaries/salary_updater'
+require 'salaries/salary_updater'
 
 describe SalaryUpdater do
   def create_monthly_salaries

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -6,7 +6,7 @@ ENV["RAILS_ENV"] ||= 'test'
 require File.expand_path("../../config/environment", __FILE__)
 require 'rspec/rails'
 
-require './lib/ar_repository/ar_repository'
+require 'ar_repository/ar_repository'
 
 Dir[Rails.root.join("spec/support/**/*.rb")].each { |f| require f }
 


### PR DESCRIPTION
This PR removes the `./lib/` prefix to `require` paths. They are not necessary, and cause problems when running the actual application.