### PR TITLE
Define basic configuration for automating unicorn

### DIFF
--- a/Capfile
+++ b/Capfile
@@ -41,6 +41,9 @@ require "capistrano/rvm"
 require "capistrano/bundler"
 require "capistrano/rails/assets"
 
+# Include Unicorn tasks to restart server
+require 'capistrano3/unicorn'
+
 # Only include the Rails migrations tasks if the env var RUN_MIGRATIONS is truthy
 # @see https://capistranorb.com/documentation/tasks/rails/ for usage instructions
 require "capistrano/rails/migrations" if ENV['RUN_MIGRATIONS']

--- a/Gemfile
+++ b/Gemfile
@@ -38,6 +38,7 @@ group :test, :development do
   gem "capistrano", :require => false
   gem "capistrano-rails", "~> 1.4", require: false
   gem "capistrano-rvm", require: false
+  gem 'capistrano3-unicorn', require: false
 end
 
 gem 'simplecov', :require => false, :group => :test

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -64,6 +64,8 @@ GEM
     capistrano-rvm (0.1.2)
       capistrano (~> 3.0)
       sshkit (~> 1.2)
+    capistrano3-unicorn (0.2.1)
+      capistrano (~> 3.1, >= 3.1.0)
     coderay (1.1.1)
     coffee-rails (4.0.1)
       coffee-script (>= 2.2.0)
@@ -262,6 +264,7 @@ DEPENDENCIES
   capistrano
   capistrano-rails (~> 1.4)
   capistrano-rvm
+  capistrano3-unicorn
   coffee-rails (~> 4.0.0)
   edn (~> 1.0.2)
   guard (~> 2.14)

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -44,3 +44,11 @@ append :linked_dirs, "log", "tmp/pids", "tmp/cache", "tmp/sockets", "public/syst
 
 # Uncomment the following to require manually verifying the host key before first deploy.
 # set :ssh_options, verify_host_key: :secure
+
+# Restart unicorn after deploy
+after 'deploy:publishing', 'deploy:restart'
+namespace :deploy do
+  task :restart do
+    invoke 'unicorn:restart'
+  end
+end

--- a/config/unicorn/production.rb
+++ b/config/unicorn/production.rb
@@ -1,0 +1,51 @@
+# set path to application
+app_dir = File.expand_path("../..", __FILE__)
+shared_dir = "#{app_dir}/tmp"
+log_dir = "#{app_dir}/log"
+working_directory app_dir
+
+
+# Set unicorn options
+worker_processes 2
+preload_app true
+timeout 30
+
+# Set up socket location
+listen "#{shared_dir}/sockets/unicorn.sock", :backlog => 64
+
+# Logging
+stderr_path "#{log_dir}/unicorn.stderr.log"
+stdout_path "#{log_dir}/unicorn.stdout.log"
+
+# Set master PID location
+pid "#{shared_dir}/pids/unicorn.pid"
+
+# use correct Gemfile on restarts
+before_exec do |server|
+  ENV['BUNDLE_GEMFILE'] = "#{app_path}/Gemfile"
+end
+
+before_fork do |server, worker|
+  # the following is highly recomended for Rails + "preload_app true"
+  # as there's no need for the master process to hold a connection
+  if defined?(ActiveRecord::Base)
+    ActiveRecord::Base.connection.disconnect!
+  end
+
+  # Before forking, kill the master process that belongs to the .oldbin PID.
+  # This enables 0 downtime deploys.
+  old_pid = "#{server.config[:pid]}.oldbin"
+  if File.exists?(old_pid) && server.pid != old_pid
+    begin
+      Process.kill("QUIT", File.read(old_pid).to_i)
+    rescue Errno::ENOENT, Errno::ESRCH
+      # someone else did our job for us
+    end
+  end
+end
+
+after_fork do |server, worker|
+  if defined?(ActiveRecord::Base)
+    ActiveRecord::Base.establish_connection
+  end
+end


### PR DESCRIPTION
This PR adds config to restart unicorn on deploy, and adds a basic production unicorn config that lines up with how Capistrano manages releases. We'll also need to update the nginx config for this to work, but for now that can be done manually.