### PR TITLE
Unicorn config: Fix path to app_dir

### DIFF
--- a/config/unicorn/production.rb
+++ b/config/unicorn/production.rb
@@ -1,5 +1,5 @@
 # set path to application
-app_dir = File.expand_path("../../..", __FILE__)
+app_dir = File.expand_path("../../../..", __FILE__)
 shared_dir = "#{app_dir}/current/tmp"
 log_dir = "#{app_dir}/current/log"
 working_directory "#{app_dir}/current"


### PR DESCRIPTION
This PR corrects an invalid path to the application directory. Should hopefully fix the Unicorn Capistrano stuff.