### PR TITLE
Deploy to master only, always use RAILS_ENV=staging

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -10,7 +10,7 @@ set :branch, "master"
 
 # Default deploy_to directory is /var/www/my_app_name
 # set :deploy_to, "/var/www/my_app_name"
-set :deploy_to, "#{ENV['CAPISTRANO_PRODUCTION_DEPLOY_TO']}"
+set :deploy_to, "#{ENV['CAPISTRANO_STAGING_DEPLOY_TO']}"
 
 # Default value for :format is :airbrussh.
 # set :format, :airbrussh

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -40,7 +40,7 @@ append :linked_dirs, "log", "tmp/pids", "tmp/cache", "tmp/sockets", "public/syst
 # set :local_user, -> { `git config user.name`.chomp }
 
 # Default value for keep_releases is 5
-# set :keep_releases, 5
+set :keep_releases, 100
 
 # Uncomment the following to require manually verifying the host key before first deploy.
 # set :ssh_options, verify_host_key: :secure

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -31,7 +31,7 @@ append :linked_files, "config/database.yml"
 append :linked_files, "config/mailer.yml"
 
 # Default value for linked_dirs is []
-append :linked_dirs, "log", "tmp/pids", "tmp/cache", "tmp/sockets", "public/system"
+append :linked_dirs, "log", "tmp/cache", "public/system"
 
 # Default value for default_env is {}
 # set :default_env, { path: "/opt/ruby/bin:$PATH" }

--- a/config/deploy/staging.rb
+++ b/config/deploy/staging.rb
@@ -13,9 +13,6 @@ server "#{ENV['CAPISTRANO_SERVER']}",
     keys: "#{ENV['CAPISTRANO_DEPLOY_PATH_TO_SSH_KEY']}"
   }
 
-# Deploy the "develop" branch to the staging environment
-set :branch, "develop"
-
 # Set the :deploy_to filepath to point to the folder for the staging app
 set :deploy_to, "#{ENV['CAPISTRANO_STAGING_DEPLOY_TO']}"
 

--- a/config/deploy/staging.rb
+++ b/config/deploy/staging.rb
@@ -13,11 +13,8 @@ server "#{ENV['CAPISTRANO_SERVER']}",
     keys: "#{ENV['CAPISTRANO_DEPLOY_PATH_TO_SSH_KEY']}"
   }
 
-# Set the :deploy_to filepath to point to the folder for the staging app
-set :deploy_to, "#{ENV['CAPISTRANO_STAGING_DEPLOY_TO']}"
-
-# App running in staging environment should use the "production" environment config
-set :rails_env, "production"
+# App running in staging environment should use the "staging" environment config
+set :rails_env, "staging"
 
 # role-based syntax
 # ==================

--- a/config/unicorn/production.rb
+++ b/config/unicorn/production.rb
@@ -1,8 +1,8 @@
 # set path to application
-app_dir = File.expand_path("../../../..", __FILE__)
-shared_dir = "#{app_dir}/current/tmp"
-log_dir = "#{app_dir}/current/log"
-working_directory "#{app_dir}/current"
+app_dir = File.expand_path("../../..", __FILE__)
+shared_dir = "#{app_dir}/tmp"
+log_dir = "#{app_dir}/log"
+working_directory "#{app_dir}"
 
 
 # Set unicorn options
@@ -22,7 +22,7 @@ pid "#{shared_dir}/pids/unicorn.pid"
 
 # use correct Gemfile on restarts
 before_exec do |server|
-  ENV['BUNDLE_GEMFILE'] = "#{app_dir}/current/Gemfile"
+  ENV['BUNDLE_GEMFILE'] = "#{app_dir}/Gemfile"
 end
 
 before_fork do |server, worker|


### PR DESCRIPTION
We should only ever deploy the master branch; develop no longer exists.

The automatic unicorn restarts should also always set `RAILS_ENV=staging`.