### PR TITLE
Always deploy to inactive node

### DIFF
--- a/.cap_env.example
+++ b/.cap_env.example
@@ -12,6 +12,10 @@ set -o allexport
 # $> vim .cap_env # Set the correct values for your local machine
 # $> source .cap_env # Load the environment vars into your shell session
 
+# Your AWS credentials
+AWS_ACCESS_KEY_ID=someawsaccesskey
+AWS_SECRET_ACCESS_KEY=someawssecretaccesskey
+
 # User with deploy privileges on target machine
 CAPISTRANO_DEPLOY_USER=somedeployuser
 

--- a/.cap_env.example
+++ b/.cap_env.example
@@ -12,9 +12,6 @@ set -o allexport
 # $> vim .cap_env # Set the correct values for your local machine
 # $> source .cap_env # Load the environment vars into your shell session
 
-# IP address or hostname to deploy to
-CAPISTRANO_SERVER=some.server-address-here.com
-
 # User with deploy privileges on target machine
 CAPISTRANO_DEPLOY_USER=somedeployuser
 

--- a/Capfile
+++ b/Capfile
@@ -48,5 +48,8 @@ require 'capistrano3/unicorn'
 # @see https://capistranorb.com/documentation/tasks/rails/ for usage instructions
 require "capistrano/rails/migrations" if ENV['RUN_MIGRATIONS']
 
+# Include the BlueGreenIpClient
+require_relative "./lib/blue_green_ip_client.rb"
+
 # Load custom tasks from `lib/capistrano/tasks` if you have any defined
 Dir.glob("lib/capistrano/tasks/*.rake").each { |r| import r }

--- a/Gemfile
+++ b/Gemfile
@@ -38,7 +38,9 @@ group :test, :development do
   gem "capistrano", :require => false
   gem "capistrano-rails", "~> 1.4", require: false
   gem "capistrano-rvm", require: false
-  gem 'capistrano3-unicorn', require: false
+  gem "capistrano3-unicorn", require: false
+  gem "aws-sdk-elasticloadbalancingv2"
+  gem "aws-sdk-ec2"
 end
 
 gem 'simplecov', :require => false, :group => :test

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -46,6 +46,20 @@ GEM
     american_date (1.1.1)
     arel (4.0.2)
     awesome_print (1.8.0)
+    aws-eventstream (1.0.1)
+    aws-partitions (1.105.0)
+    aws-sdk-core (3.31.0)
+      aws-eventstream (~> 1.0)
+      aws-partitions (~> 1.0)
+      aws-sigv4 (~> 1.0)
+      jmespath (~> 1.0)
+    aws-sdk-ec2 (1.51.0)
+      aws-sdk-core (~> 3, >= 3.26.0)
+      aws-sigv4 (~> 1.0)
+    aws-sdk-elasticloadbalancingv2 (1.14.0)
+      aws-sdk-core (~> 3, >= 3.26.0)
+      aws-sigv4 (~> 1.0)
+    aws-sigv4 (1.0.3)
     better_errors (1.1.0)
       coderay (>= 1.0.0)
       erubis (>= 2.6.6)
@@ -103,6 +117,7 @@ GEM
       json (~> 1.8)
       multi_xml (>= 0.5.2)
     i18n (0.8.4)
+    jmespath (1.4.0)
     jquery-rails (3.1.4)
       railties (>= 3.0, < 5.0)
       thor (>= 0.14, < 2.0)
@@ -260,6 +275,8 @@ DEPENDENCIES
   activerecord-native_db_types_override
   american_date
   awesome_print
+  aws-sdk-ec2
+  aws-sdk-elasticloadbalancingv2
   better_errors (= 1.1.0)
   capistrano
   capistrano-rails (~> 1.4)
@@ -294,3 +311,6 @@ DEPENDENCIES
   uglifier (>= 1.3.0)
   unicorn (~> 4.8.2)
   will_paginate (~> 3.0.5)
+
+BUNDLED WITH
+   1.16.4

--- a/config/deploy/production.rb
+++ b/config/deploy/production.rb
@@ -6,7 +6,11 @@
 # server "example.com", user: "deploy", roles: %w{app db web}, my_property: :my_value
 # server "example.com", user: "deploy", roles: %w{app web}, other_property: :other_value
 # server "db.example.com", user: "deploy", roles: %w{db}
-server "#{ENV['CAPISTRANO_SERVER']}",
+client = BlueGreenIpClient.new
+
+ips = client.get_ips
+
+server "#{ips[:inactive_ip]}",
   user: "#{ENV['CAPISTRANO_DEPLOY_USER']}",
   roles: %w{app db web},
   ssh_options: {

--- a/lib/blue_green_ip_client.rb
+++ b/lib/blue_green_ip_client.rb
@@ -1,0 +1,88 @@
+require 'aws-sdk-elasticloadbalancingv2'
+require 'aws-sdk-ec2'
+
+class BlueGreenIpClient
+  ELB_NAME='blue-green-elb'
+
+  def initialize()
+    @elb_client = Aws::ElasticLoadBalancingV2::Client.new(region: 'us-east-1')
+    @ec2_client = Aws::EC2::Client.new(region: 'us-east-1')
+  end
+
+  # Get a hash of public IP addresses, where the key is the active/inactive
+  # state, and the value is the public IP address
+  def get_ips
+    blue_green_elb_arn = get_blue_green_elb_arn()
+
+    get_ips_from_blue_green_elb_arn(blue_green_elb_arn)
+  end
+
+  private
+
+  def get_ips_from_blue_green_elb_arn(blue_green_elb_arn)
+    active_target_group_arn = get_active_target_group_arn(blue_green_elb_arn)
+
+    all_target_groups = get_all_target_groups()
+
+    active_target_group   = all_target_groups.find{
+      |t| t.target_group_arn == active_target_group_arn
+    }
+
+    inactive_target_group = all_target_groups.find{
+      |t| t.target_group_arn != active_target_group_arn
+    }
+
+    active_ec2_id   = get_target_group_instance_id(
+      active_target_group.target_group_arn
+    )
+
+    inactive_ec2_id = get_target_group_instance_id(
+      inactive_target_group.target_group_arn
+    )
+
+    ips = {
+      :active_ip   => get_ec2_public_ip_by_id(active_ec2_id),
+      :inactive_ip => get_ec2_public_ip_by_id(inactive_ec2_id),
+    }
+  end
+
+  def get_blue_green_elb_arn
+    resp = @elb_client.describe_load_balancers
+
+    blue_green_elb = resp.load_balancers.find{
+      |elb| elb.load_balancer_name == BlueGreenIpClient::ELB_NAME
+    }
+
+    blue_green_elb.load_balancer_arn
+  end
+
+  def get_active_target_group_arn(load_balancer_arn)
+    resp = @elb_client.describe_listeners({
+      load_balancer_arn: load_balancer_arn,
+    })
+
+    resp.listeners[0].default_actions[0].target_group_arn
+  end
+
+  def get_all_target_groups()
+    resp = @elb_client.describe_target_groups().target_groups
+  end
+
+  def get_target_group_instance_id(target_group_arn)
+    resp = @elb_client.describe_target_health({
+      target_group_arn: target_group_arn,
+    })
+
+    resp.target_health_descriptions[0].target.id
+  end
+
+  def get_ec2_public_ip_by_id(ec2_id)
+    resp = @ec2_client.describe_instances({
+      instance_ids: [
+        ec2_id,
+      ],
+    })
+
+    resp.reservations[0].instances[0].public_ip_address
+  end
+end


### PR DESCRIPTION
This PR adds a funky script that knows how to look up the public IP address of the active and the inactive node, and configures the cap production deploy task to _always_ prefer the inactive node as a target.

PLEASE give me feedback about my ruby. i also feel dirty because i did this without writing tests, so i intend to fix that, but i was hacking at this just to have something for class tomorrow. :(